### PR TITLE
fixed small typo with user account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Once a smart contract has been deployed it must be initialized.
 Initialize This contract by running the following
 
 ```bash
-near call <dev-account> init --accountId 'blockhead.testnet'
+near call <dev-account> init --accountId <your-account.testnet>
 ```
 
 ## Calling methods from terminal


### PR DESCRIPTION
left one of my example call names in the bash examples fixed the typo